### PR TITLE
Remove 'using namespace std'

### DIFF
--- a/include/parser.h
+++ b/include/parser.h
@@ -1,12 +1,10 @@
 #include "json.hpp"
+#include <string>
 
 #ifndef WEBHOOK_PARSER_H
 #define WEBHOOK_PARSER_H
 
-//#include "json.hpp"
-
 using json = nlohmann::json;
-using namespace std;
 
 class Parser {
 
@@ -16,21 +14,21 @@ class Parser {
 public:
     Parser();
 
-    Parser(string json_message);
+    Parser(std::string json_message);
 
-    string get_action();
+    std::string get_action();
 
-    string get_pr_url();
+    std::string get_pr_url();
 
-    string get_clone_url();
+    std::string get_clone_url();
 
-    string get_pr_title();
+    std::string get_pr_title();
 
-    string get_pr_body();
+    std::string get_pr_body();
 
-    string get_pr_time();
+    std::string get_pr_time();
 
-    string get_pr_user();
+    std::string get_pr_user();
 };
 
 #endif //WEBHOOK_PARSER_H

--- a/source/parser.cpp
+++ b/source/parser.cpp
@@ -1,8 +1,8 @@
 #include "parser.h"
 #include <iostream>
+#include <string>
 
 using json = nlohmann::json;
-using namespace std;
 
 
     json test = R"({
@@ -204,41 +204,41 @@ using namespace std;
         this->message = test;
     }
     // Initialize with a given string
-    Parser::Parser(string json_message){
+    Parser::Parser(std::string json_message){
         this->message = json::parse(json_message);
     }
 
     // Return the pull request action (opened, edited, closed, merged, etc)
-    string Parser::get_action(){
+    std::string Parser::get_action(){
         return this->message["action"];
     }
 
     // Returns the url of the pull request
-    string Parser::get_pr_url(){
+    std::string Parser::get_pr_url(){
         return this->message["pull_request"]["url"];
     }
 
     // Returns the clone url of the repo
-    string Parser::get_clone_url(){
+    std::string Parser::get_clone_url(){
         return this->message["pull_request"]["head"]["repo"]["clone_url"];
     }
 
     // Returns the title of the pull request
-    string Parser::get_pr_title(){
+    std::string Parser::get_pr_title(){
         return this->message["pull_request"]["title"];
     }
 
     // Returns the body of the pull request
-    string Parser::get_pr_body(){
+    std::string Parser::get_pr_body(){
         return this->message["pull_request"]["body"];
     }
 
     // Returns the time and date that the pull request was created
-    string Parser::get_pr_time(){
+    std::string Parser::get_pr_time(){
         return this->message["pull_request"]["created_at"];
     }
 
     // Returns the username of the creator of the pull request
-    string Parser::get_pr_user(){
+    std::string Parser::get_pr_user(){
         return this->message["pull_request"]["user"]["login"];
     }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3,13 +3,12 @@
 #include <json.hpp>
 
 using json = nlohmann::json;
-using namespace std;
 
 
 // Test file to test the functions in the Parser class
 
 // Help variable
-string test_string = R"V0G0N(
+std::string test_string = R"V0G0N(
     {
       "action": "closed",
       "pull_request": {


### PR DESCRIPTION
Remove 'using namespace std' from parser files to resolve conflicts, fixes #19.